### PR TITLE
Refine local persistence, typing, and form validation

### DIFF
--- a/app/api/ai/generate-curriculum/route.ts
+++ b/app/api/ai/generate-curriculum/route.ts
@@ -4,7 +4,8 @@ import { groq } from "@ai-sdk/groq"
 export const maxDuration = 60
 
 export async function POST(req: Request) {
-  const { researchQuery, researchContext, childName, duration, learningStyle, focusAreas } = await req.json()
+  const { researchQuery, researchContext, childName, duration, learningStyle, focusAreas, stateRequirements } =
+    await req.json()
 
   const systemPrompt = `You are a master homeschool curriculum designer.
   You will be given a research context containing a list of online resources, along with a child's details and desired curriculum structure.
@@ -15,7 +16,8 @@ export async function POST(req: Request) {
   2.  **Structure the Curriculum:** Create a curriculum with a clear title, a brief description, a list of 3-5 high-level learning objectives, and a week-by-week lesson plan.
   3.  **Personalize:** Tailor the activities and suggestions to the child's name, specified learning style (if any), and focus areas. For example, for a 'Kinesthetic' learner, suggest more hands-on activities.
   4.  **Weekly Plan:** For each week, provide a clear theme or topic, and a brief description of the activities. Reference the provided URLs from the research context where appropriate.
-  5.  **Output Format:** Respond with a single, valid JSON object. Do not include any text or markdown formatting before or after the JSON.
+  5.  **State Requirements:** If state requirements are provided, align the curriculum to those requirements.
+  6.  **Output Format:** Respond with a single, valid JSON object. Do not include any text or markdown formatting before or after the JSON.
 
   **JSON Schema:**
   {
@@ -42,6 +44,7 @@ export async function POST(req: Request) {
   - Duration: ${duration}
   - Learning Style: ${learningStyle || "Balanced"}
   - Focus Areas: ${focusAreas || "Core concepts"}
+  - State Requirements: ${stateRequirements || "None provided"}
 
   Generate the curriculum now.
   `

--- a/app/api/ai/research/route.ts
+++ b/app/api/ai/research/route.ts
@@ -6,7 +6,7 @@ import { searchWeb } from "@/lib/tools/search"
 export const maxDuration = 30
 
 export async function POST(req: Request) {
-  const { subject, grade, topics } = await req.json()
+  const { subject, grade, topics, state } = await req.json()
 
   const result = await streamText({
     model: groq("llama3-70b-8192"),
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
     Prioritize sources from reputable institutions like universities, museums, and well-known educational companies (e.g., Khan Academy, PBS Kids, National Geographic).
     For each resource you find, provide a concise summary of why it's relevant.
     Return a list of at least 5 and at most 10 resources.`,
-    prompt: `Find curriculum resources for the subject: ${subject}, for grade: ${grade}. The key topics of interest are: ${topics}.`,
+    prompt: `Find curriculum resources for the subject: ${subject}, for grade: ${grade}. The key topics of interest are: ${topics}.${state ? ` Align results with ${state} homeschool requirements.` : ""}`,
     tools: {
       searchWeb: {
         description: "Search the web for educational resources based on a query.",

--- a/app/community/events/create/page.tsx
+++ b/app/community/events/create/page.tsx
@@ -1,4 +1,8 @@
+"use client"
+
+import { FormEvent, useState } from "react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { ArrowLeft } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -9,8 +13,53 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import Navigation from "@/components/navigation"
 import { Footer } from "@/components/footer"
+import { loadFromStorage, saveToStorage } from "@/lib/local-storage"
+
+const EVENTS_STORAGE_KEY = "homeschoolEvents"
 
 export default function CreateEventPage() {
+  const router = useRouter()
+  const [formData, setFormData] = useState({
+    title: "",
+    description: "",
+    date: "",
+    time: "",
+    location: "",
+    address: "",
+    type: "",
+    cost: "",
+    ageGroup: "",
+  })
+
+  const handleChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!formData.title || !formData.date || !formData.type) {
+      return
+    }
+
+    const storedEvents = loadFromStorage(EVENTS_STORAGE_KEY, [])
+    const dateTime = formData.time ? `${formData.date}T${formData.time}` : `${formData.date}T09:00:00`
+
+    const newEvent = {
+      id: typeof crypto !== "undefined" ? crypto.randomUUID() : `${Date.now()}`,
+      title: formData.title,
+      description: formData.description,
+      date: dateTime,
+      location: formData.location || formData.address,
+      attendees: 0,
+      type: formData.type,
+      tags: [formData.ageGroup || "All Ages"].filter(Boolean),
+      cost: formData.cost,
+    }
+
+    saveToStorage(EVENTS_STORAGE_KEY, [...storedEvents, newEvent])
+    router.push("/community")
+  }
+
   return (
     <div className="min-h-screen flex flex-col">
       <Navigation />
@@ -32,73 +81,112 @@ export default function CreateEventPage() {
               <CardDescription>Share your homeschool event with the community</CardDescription>
             </CardHeader>
             <CardContent>
-              <form className="space-y-6">
+              <form className="space-y-6" onSubmit={handleSubmit}>
                 <div className="space-y-2">
                   <Label htmlFor="title">Event Title</Label>
-                  <Input id="title" placeholder="Enter the name of your event" />
+                  <Input
+                    id="title"
+                    placeholder="Enter the name of your event"
+                    value={formData.title}
+                    onChange={(event) => handleChange("title", event.target.value)}
+                    required
+                  />
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="description">Description</Label>
-                  <Textarea id="description" placeholder="Describe your event" className="min-h-[120px]" />
+                  <Textarea
+                    id="description"
+                    placeholder="Describe your event"
+                    className="min-h-[120px]"
+                    value={formData.description}
+                    onChange={(event) => handleChange("description", event.target.value)}
+                  />
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="date">Date</Label>
-                    <Input id="date" type="date" />
+                    <Input
+                      id="date"
+                      type="date"
+                      value={formData.date}
+                      onChange={(event) => handleChange("date", event.target.value)}
+                      required
+                    />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="time">Time</Label>
-                    <Input id="time" type="time" />
+                    <Input
+                      id="time"
+                      type="time"
+                      value={formData.time}
+                      onChange={(event) => handleChange("time", event.target.value)}
+                    />
                   </div>
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="location">Location</Label>
-                  <Input id="location" placeholder="Enter the venue name" />
+                  <Input
+                    id="location"
+                    placeholder="Enter the venue name"
+                    value={formData.location}
+                    onChange={(event) => handleChange("location", event.target.value)}
+                    required
+                  />
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="address">Address</Label>
-                  <Input id="address" placeholder="Enter the full address" />
+                  <Input
+                    id="address"
+                    placeholder="Enter the full address"
+                    value={formData.address}
+                    onChange={(event) => handleChange("address", event.target.value)}
+                  />
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="type">Event Type</Label>
-                  <Select>
+                  <Select value={formData.type} onValueChange={(value) => handleChange("type", value)}>
                     <SelectTrigger id="type">
                       <SelectValue placeholder="Select event type" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="workshop">Workshop</SelectItem>
-                      <SelectItem value="field-trip">Field Trip</SelectItem>
-                      <SelectItem value="social">Social Gathering</SelectItem>
-                      <SelectItem value="class">Class</SelectItem>
-                      <SelectItem value="meeting">Meeting</SelectItem>
-                      <SelectItem value="other">Other</SelectItem>
+                      <SelectItem value="Workshop">Workshop</SelectItem>
+                      <SelectItem value="Field Trip">Field Trip</SelectItem>
+                      <SelectItem value="Social Gathering">Social Gathering</SelectItem>
+                      <SelectItem value="Class">Class</SelectItem>
+                      <SelectItem value="Meeting">Meeting</SelectItem>
+                      <SelectItem value="Other">Other</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="cost">Cost</Label>
-                  <Input id="cost" placeholder="Free or enter amount" />
+                  <Input
+                    id="cost"
+                    placeholder="Free or enter amount"
+                    value={formData.cost}
+                    onChange={(event) => handleChange("cost", event.target.value)}
+                  />
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="age-group">Age Group</Label>
-                  <Select>
+                  <Select value={formData.ageGroup} onValueChange={(value) => handleChange("ageGroup", value)}>
                     <SelectTrigger id="age-group">
                       <SelectValue placeholder="Select age group" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="all">All Ages</SelectItem>
-                      <SelectItem value="preschool">Preschool</SelectItem>
-                      <SelectItem value="elementary">Elementary</SelectItem>
-                      <SelectItem value="middle">Middle School</SelectItem>
-                      <SelectItem value="high">High School</SelectItem>
-                      <SelectItem value="parents">Parents Only</SelectItem>
+                      <SelectItem value="All Ages">All Ages</SelectItem>
+                      <SelectItem value="Preschool">Preschool</SelectItem>
+                      <SelectItem value="Elementary">Elementary</SelectItem>
+                      <SelectItem value="Middle School">Middle School</SelectItem>
+                      <SelectItem value="High School">High School</SelectItem>
+                      <SelectItem value="Parents Only">Parents Only</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/app/community/groups/create/page.tsx
+++ b/app/community/groups/create/page.tsx
@@ -41,11 +41,17 @@ export default function CreateGroupPage() {
 
     const storedGroups = loadFromStorage(GROUPS_STORAGE_KEY, [])
     const scheduleLower = formData.meetingSchedule.toLowerCase()
-    const frequencyTag = scheduleLower.includes("week")
-      ? "Weekly"
-      : scheduleLower.includes("month")
-        ? "Monthly"
-        : ""
+    const frequencyTag = scheduleLower.includes("quarter")
+      ? "Quarterly"
+      : scheduleLower.includes("bi-week") ||
+          scheduleLower.includes("bi week") ||
+          scheduleLower.includes("every other week")
+        ? "Bi-weekly"
+        : scheduleLower.includes("week")
+          ? "Weekly"
+          : scheduleLower.includes("month")
+            ? "Monthly"
+            : ""
 
     const newGroup = {
       id: typeof crypto !== "undefined" ? crypto.randomUUID() : `${Date.now()}`,

--- a/components/ai-curriculum-generation-phase.tsx
+++ b/components/ai-curriculum-generation-phase.tsx
@@ -25,7 +25,7 @@ const curriculumSchema = z.object({
 type CurriculumFormValues = z.infer<typeof curriculumSchema>
 
 interface AICurriculumGenerationPhaseProps {
-  researchQuery: { subject: string; grade: string; topics: string }
+  researchQuery: { subject: string; grade: string; topics: string; state?: string }
   researchResults: ResearchResult[]
   onStartOver: () => void
 }
@@ -48,6 +48,7 @@ export default function AICurriculumGenerationPhase({
         ...data,
         researchQuery,
         researchContext: researchResults,
+        stateRequirements: researchQuery.state,
       }
       const response = await fetch("/api/ai/generate-curriculum", {
         method: "POST",
@@ -129,8 +130,14 @@ export default function AICurriculumGenerationPhase({
           <p className="text-sm text-muted-foreground mb-3">
             Based on your query for <Badge variant="secondary">{researchQuery.subject}</Badge> for{" "}
             <Badge variant="secondary">Grade {researchQuery.grade}</Badge> focusing on{" "}
-            <Badge variant="secondary">{researchQuery.topics}</Badge>, we found {researchResults.length} relevant
-            resources.
+            <Badge variant="secondary">{researchQuery.topics}</Badge>
+            {researchQuery.state ? (
+              <>
+                {" "}
+                with <Badge variant="secondary">{researchQuery.state}</Badge> requirements
+              </>
+            ) : null}
+            , we found {researchResults.length} relevant resources.
           </p>
           <div className="space-y-2 max-h-40 overflow-y-auto">
             {researchResults.map((res, i) => (

--- a/components/ai-curriculum-workflow.tsx
+++ b/components/ai-curriculum-workflow.tsx
@@ -7,15 +7,16 @@ import type { ResearchResult } from "@/lib/types"
 
 export default function AICurriculumWorkflow() {
   const [step, setStep] = useState<"research" | "generate">("research")
-  const [researchQuery, setResearchQuery] = useState<{ subject: string; grade: string; topics: string }>({
-    subject: "",
-    grade: "",
-    topics: "",
-  })
+  const [researchQuery, setResearchQuery] = useState<{
+    subject: string
+    grade: string
+    topics: string
+    state?: string
+  }>({ subject: "", grade: "", topics: "", state: "" })
   const [researchResults, setResearchResults] = useState<ResearchResult[]>([])
 
   const handleResearchComplete = (
-    query: { subject: string; grade: string; topics: string },
+    query: { subject: string; grade: string; topics: string; state?: string },
     results: ResearchResult[],
   ) => {
     setResearchQuery(query)
@@ -25,7 +26,7 @@ export default function AICurriculumWorkflow() {
 
   const handleStartOver = () => {
     setStep("research")
-    setResearchQuery({ subject: "", grade: "", topics: "" })
+    setResearchQuery({ subject: "", grade: "", topics: "", state: "" })
     setResearchResults([])
   }
 

--- a/components/ai-research-phase.tsx
+++ b/components/ai-research-phase.tsx
@@ -17,6 +17,7 @@ const researchSchema = z.object({
   subject: z.string().min(1, "Subject is required"),
   grade: z.string().min(1, "Grade level is required"),
   topics: z.string().min(3, "Please specify topics of interest."),
+  state: z.string().optional(),
 })
 
 type ResearchFormValues = z.infer<typeof researchSchema>
@@ -29,7 +30,7 @@ export default function AIResearchPhase({ onResearchComplete }: AIResearchPhaseP
   const { toast } = useToast()
   const form = useForm<ResearchFormValues>({
     resolver: zodFormResolver(researchSchema), // Using our custom resolver
-    defaultValues: { subject: "", grade: "", topics: "" },
+    defaultValues: { subject: "", grade: "", topics: "", state: "" },
   })
 
   const researchMutation = useMutation({
@@ -130,6 +131,19 @@ export default function AIResearchPhase({ onResearchComplete }: AIResearchPhaseP
                   <FormLabel>Key Topics or Interests</FormLabel>
                   <FormControl>
                     <Input placeholder="e.g., fractions, photosynthesis, American Revolution" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="state"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>State Requirements (Optional)</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g., Texas, California, Florida" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/lib/local-storage.ts
+++ b/lib/local-storage.ts
@@ -1,0 +1,28 @@
+export function loadFromStorage<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") {
+    return fallback
+  }
+
+  try {
+    const stored = window.localStorage.getItem(key)
+    if (!stored) {
+      return fallback
+    }
+    return JSON.parse(stored) as T
+  } catch (error) {
+    console.warn(`Failed to load ${key} from local storage`, error)
+    return fallback
+  }
+}
+
+export function saveToStorage<T>(key: string, value: T) {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value))
+  } catch (error) {
+    console.warn(`Failed to save ${key} to local storage`, error)
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve the MVP for local persistence and client-side UX by adding safe read/write helpers and stronger type safety for planner lessons and community items.
- Prevent accidental submissions by enforcing required fields in create forms and avoid mutating sample data (disable completion toggles for non-user lessons).
- Surface an optional state-level requirement through the AI research + curriculum generation flow so generated curricula can be aligned to state guidance when provided.

### Description
- Add `lib/local-storage.ts` with `loadFromStorage` and `saveToStorage` helpers and use the keys `plannerLessons`, `homeschoolEvents`, and `homeschoolGroups` for client-side persistence.
- Planner changes: introduce `Lesson` and `LessonFormState` types, load/save user lessons from local storage, merge sample and user lessons via `useMemo`, wire a controlled add-lesson form with required fields, and disable completion toggles for sample lessons (`app/planner/page.tsx`).
- Community changes: add `CommunityEvent` and `CommunityGroup` types, load stored events/groups and merge with samples, normalize select option values (capitalization), make create forms controlled with basic `required` validation and persist new items to local storage, and tighten client-side filtering via `useMemo` (`components/community-events.tsx`, `components/community-groups.tsx`, `app/community/events/create/page.tsx`, `app/community/groups/create/page.tsx`).
- AI flow: accept an optional `state`/`stateRequirements` field in the research and generation payloads, include it in prompts, and display the selected state in the generator UI; ensure the generator API receives `stateRequirements` (`components/ai-research-phase.tsx`, `components/ai-curriculum-generation-phase.tsx`, `components/ai-curriculum-workflow.tsx`, `app/api/ai/research/route.ts`, `app/api/ai/generate-curriculum/route.ts`).
- Minor UI wiring and type refinements across affected components to use controlled inputs and improve runtime safety.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`; server booted and served `/community` (HTTP 200) but the build logged repeated Google Fonts fetch warnings (fonts failed to download) which did not block the page from rendering.
- Ran a Playwright script that opened `http://127.0.0.1:3000/community` and captured a screenshot; the script completed and produced the artifact successfully.
- No unit or CI test-suite jobs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698106784acc832d8adb541f51df1177)

## Summary by Sourcery

Refine local client-side persistence, typing, and AI curriculum workflow to better handle user-created planner and community data while supporting optional state-level requirements in AI-powered curriculum generation and research.

New Features:
- Introduce a reusable local storage helper module and persist user-created planner lessons, community events, and groups in the browser.
- Allow users to create planner lessons, community events, and community groups through controlled forms that save entries locally and appear alongside sample data.
- Extend the AI curriculum research and generation workflow to accept optional state requirements and display them in the UI.

Bug Fixes:
- Enforce required fields on planner and community creation forms to reduce accidental or incomplete submissions.

Enhancements:
- Strengthen typing and state management for planner lessons and community community items, including typed models and memoized filtering.
- Prevent sample planner lessons from being mutated by restricting completion toggles to user-created lessons only.
- Tighten client-side filtering and option value normalization for community events and groups to improve consistency and UX.