### PR TITLE
Fix MVP review blockers: /today, kid view, /reset-password + /people dev overlay

### DIFF
--- a/app/family/kid/[kidId]/page.tsx
+++ b/app/family/kid/[kidId]/page.tsx
@@ -94,7 +94,7 @@ export default function KidPage() {
 
   return (
     <div className="min-h-screen bg-[var(--linen)] text-[var(--ink)] font-sans">
-      <Topbar onLogHours={() => setLogOpen(true)} />
+      <Navigation />
       <main className="atoz-page">
         <div className="text-xs text-[var(--ink-3)] mb-2">
           <Link href="/today" className="hover:text-[var(--ink)]">← Today</Link>

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -335,16 +335,6 @@ export default function TodayPage() {
           </div>
         </section>
       </main>
-
-      <LogHoursDialog
-        open={logOpen}
-        onOpenChange={setLogOpen}
-        children={DEMO_KIDS}
-        defaultKidId="emma"
-        defaultSubject="Mathematics"
-        defaultMinutes={30}
-        onSubmit={handleQuickLog}
-      />
     </div>
   )
 }

--- a/components/db-initializer.tsx
+++ b/components/db-initializer.tsx
@@ -12,12 +12,8 @@ export function DbInitializer() {
     // Auto-initialize database tables on first app load.
     // Missing Postgres config is expected in local dev; don't surface it.
     fetch("/api/init-db", { method: "POST" })
-      .then(async (r) => {
-        if (!r.ok) return null
-        const text = await r.text()
-        return text ? (JSON.parse(text) as { success?: boolean; error?: string }) : null
-      })
-      .then((result) => {
+      .then((r) => (r.ok ? r.json().catch(() => null) : null))
+      .then((result: { success?: boolean; error?: string } | null) => {
         if (!result) return
         if (result.success) {
           console.log("[DB] Tables initialized")

--- a/components/db-initializer.tsx
+++ b/components/db-initializer.tsx
@@ -9,18 +9,24 @@ export function DbInitializer() {
     if (initialized.current) return
     initialized.current = true
 
-    // Auto-initialize database tables on first app load
+    // Auto-initialize database tables on first app load.
+    // Missing Postgres config is expected in local dev; don't surface it.
     fetch("/api/init-db", { method: "POST" })
-      .then(r => r.json())
-      .then(result => {
+      .then(async (r) => {
+        if (!r.ok) return null
+        const text = await r.text()
+        return text ? (JSON.parse(text) as { success?: boolean; error?: string }) : null
+      })
+      .then((result) => {
+        if (!result) return
         if (result.success) {
           console.log("[DB] Tables initialized")
-        } else {
+        } else if (result.error) {
           console.warn("[DB] Init warning:", result.error)
         }
       })
       .catch(() => {
-        // Silently fail - tables may already exist
+        // Silently fail - tables may already exist or Postgres isn't configured.
       })
   }, [])
 


### PR DESCRIPTION
Fixes the three ship-blocking issues from the MVP review tracker (#37).

## Summary
- `/today` no longer crashes — removed the dead `<LogHoursDialog>` block that referenced undefined `logOpen` / `setLogOpen` / `handleQuickLog`. `Navigation` already renders a global LogHoursDialog via the Log-hours FAB, so the page-level instance was never wired up.
- `/family/kid/[kidId]` no longer stuck in infinite loading — swapped the undefined `<Topbar onLogHours={() => setLogOpen(true)} />` for `<Navigation />`, which is what every other calm room uses.
- `/reset-password` + `/people` no longer surface spurious "Unexpected end of JSON input" overlays — hardened `db-initializer` so `/api/init-db` returning 500 (normal when Postgres isn't configured in local dev) doesn't make `r.json()` throw on an empty body.

## Fixes
- Closes #28 — `/today` LogHoursDialog crash
- Closes #22 — `/family/kid/[id]` infinite loading (kid-view half; `/teach/[sessionId]` half already shipped)
- Closes #26 — `/reset-password` JSON.parse SyntaxError
- Closes #31 — `/people` JSON.parse SyntaxError

## Verification

Ran `node scripts/review-screenshots.mjs` after the fix against `NEXT_PUBLIC_DEV_BYPASS_AUTH=true npm run dev`:

| Route | Before | After |
|---|---|---|
| `/today` | Error boundary: "LogHoursDialog is not defined" | 200, renders "Good morning, Rachel." hero + compliance strip + empty-state |
| `/family/kid/emma` | Stuck on `loading.tsx` spinner | 200, renders Emma's portfolio breadcrumb + stats + portfolio grid |
| `/reset-password` | HTTP 500 + dev-overlay SyntaxError | 200 |
| `/people` | HTTP 500 + dev-overlay SyntaxError | 200 |

## Test plan

- [ ] `curl -I http://localhost:3000/today` returns 200
- [ ] `curl -I http://localhost:3000/family/kid/emma` returns 200
- [ ] `curl -I http://localhost:3000/reset-password` returns 200
- [ ] `curl -I http://localhost:3000/people` returns 200
- [ ] Navigate to `/today` in the browser — no error boundary, page renders hero + sections
- [ ] Navigate to `/family/calm` → tap Emma → `/family/kid/emma` renders portfolio
- [ ] Log-hours FAB (top-right, "Log hours") still opens the dialog on `/today`, `/library`, `/family/calm`, etc. — `Navigation`'s global instance unaffected

## Not in this PR (deferred to follow-ups)
- Nested `<html>`/`<body>` hydration warning (#28 secondary finding) — layout-level, investigate separately.
- CSP blocking `api.dicebear.com` avatars on every page — one-liner in `middleware.ts:43`, filed under tracker #37.
- Duplicate footer on `/` (#23).
- The broader legacy cut list (#36) and chrome-leak fix for logged-out pages (#23-27).

Ref: review tracker #37.

https://claude.ai/code/session_01ErWrXZk2SwbE2NyayNP6qq

## Summary by Sourcery

Resolve critical MVP issues affecting /today, kid view, and local dev error overlays by hardening DB initialization and aligning page shells with the global navigation and logging flows.

Bug Fixes:
- Prevent JSON parsing errors and dev overlays when /api/init-db returns non-OK responses or empty bodies in local development.
- Remove the unused Today page–scoped LogHoursDialog instance that caused runtime crashes.
- Fix the kid detail page getting stuck in a loading state by switching it to use the shared Navigation layout.